### PR TITLE
Autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gr-tools",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gr-tools",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Commands to make my life easier",
   "main": "src/index.js",
   "scripts": {

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -1,0 +1,45 @@
+const clean = require('./clean')
+const clone = require('./clone')
+const scan = require('./scan')
+const screenshot = require('./screenshot')
+const setup = require('./setup')
+const update = require('./update')
+
+const commands = [
+  {
+    name: 'clean',
+    command: 'clean',
+    action: clean
+  },
+  {
+    name: 'clone',
+    command: 'clone <origin>',
+    targets: ['github'],
+    action: clone
+  },
+  {
+    name: 'scan',
+    command: 'scan <environment>',
+    targets: ['network'],
+    action: scan
+  },
+  {
+    name: 'screenshot',
+    command: 'screenshot',
+    action: screenshot
+  },
+  {
+    name: 'setup',
+    command: 'setup [environment]',
+    targets: ['development', 'gh', 'nvm', 'typescript'],
+    action: setup
+  },
+  {
+    name: 'update',
+    command: 'update <software>',
+    targets: ['me', 'system'],
+    action: update
+  }
+]
+
+module.exports = commands

--- a/src/completion.js
+++ b/src/completion.js
@@ -1,9 +1,19 @@
 const omelette = require('omelette')
 
-const completion = omelette('gr-tools <command>')
+const commands = require('./commands')
+
+const completion = omelette('gr-tools <command> <target>')
 
 completion.on('command', ({ reply }) => {
-  reply(['update', 'clone'])
+  reply(commands.map(({ name }) => name))
+})
+
+completion.on('target', ({ before, reply }) => {
+  const command = commands.find(({ name }) => name === before)
+
+  if (command.targets) {
+    reply(command.targets)
+  }
 })
 
 module.exports = completion


### PR DESCRIPTION
- Using strict mode
- 2.1.3
- Feedback for unexpected error using critical notify at clone.js
- removing unused param 'error' in catch
- Feedback for unexpected error using critical notify at setup.js
- Feedback for unexpected error using critical notify at update.js
- console.error at update.js catch
- 2.2.0
- npm updatte && npm audit fix
- npm update && npm audit fix
- Setup of name and email for git
- 2.3.0
- npm update && npm audit fix
- npm update && npm audit fix
- Multi setup using checkbox in terminal <3
- 2.4.0
- Avoiding break up by error in multi setup
- 2.4.1
- npm update && npm audit fix
- 2.4.2
- npm update && npm audit fix
- 2.4.3
- Removing apt node and apt npm after install nvm (setup of nvm)
- 2.4.4
- Coverage in the test command
- New package: local-devices
- Command 'scan network'
- 2.5.0
- Fixing: node => nodejs
- Increase steps to nvm setup
- 2.5.1
- npm update && npm audit fix
- 2.5.2
- Update nvm setup: all inside try/catch
- 2.5.3
- Update nvm setup: const installing before try/catch
- 2.5.4
- Update nvm setup: console.error(error.message)
- 2.5.5
- Removing jest cli from development setup
- 2.6.0
- Update package-lock.json
- 2.6.1
- Setup for github CLI
- 2.7.0
- Starting loading only after get user password
- 2.7.1
- Reading password from stdin
- 2.7.2
- Using sudo for snap connect
- Fixing: ' => `
- 2.7.3
- Receiving password from stdin
- 2.7.4
- Receiving password from stdin
- 2.7.5
- npm update && npm audit fix
- New package: omelette
- npm update && npm audit fix
- New sript: postinstall
- Lint fix
- Initial completion
- 2.8.0
- More autocomplete
- 2.9.0
