### PR TITLE
dev

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -2659,9 +2659,9 @@
       "integrity": "sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA=="
     },
     "folquire": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/folquire/-/folquire-0.1.0.tgz",
-      "integrity": "sha512-DaPF71W5cLMbY/H7mcKRU1ejAX+ZxIEDuK8oA+p2hZF9GlvHi6HMRqTa6jHJGA6q3OcKgvvxP99R+m/4/1fjDQ==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/folquire/-/folquire-0.1.1.tgz",
+      "integrity": "sha512-QRVhIMwlvUEWRfxZc646R83gQl+HGLQAApIm02dvOVBNl9rmcvqc2vA69YCN61ugfs7nl3SQlGt11fgMnbiMSA==",
       "requires": {
         "camelcase": "^6.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "commander": "^6.2.1",
     "compare-versions": "^3.6.0",
     "figlet": "^1.5.0",
-    "folquire": "^0.1.0",
+    "folquire": "^0.1.1",
     "inquirer": "^7.3.3",
     "latest-version": "^5.1.0",
     "local-devices": "^3.1.0",


### PR DESCRIPTION
- Refactoring script postinstall
- 2.26.4
- npm update && npm audit fix
- Using helper getUserPassword at update command
- Printing only the error message when user password is wrong
- 2.26.5
- New package: folquire
- update folquire
- update folquire
- Refactoring src/helpers/index.js
- 2.26.6
- npm update && npm audit fix
- 2.26.7
- npm update && npm audit fix
- 2.26.8
- npm update && npm audit fix
- Update dependency folquire
- update jest
- 2.26.9
- npm update && npm audit fix
- Screenshot command saving image in the current folder; New screenshot param: --filename
- 2.27.0
- npm update && npm audit fix
- Removing node 10.x from node.js.yml workflow
