### PR TITLE
dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gr-tools",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gr-tools",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "Commands to make my life easier",
   "main": "src/index.js",
   "scripts": {

--- a/src/commands/screenshot.js
+++ b/src/commands/screenshot.js
@@ -5,13 +5,13 @@ const shell = require('shelljs')
 
 const { verifyBin } = require('../helpers')
 
-const screenshot = ({ filename }) => {
+const screenshot = ({ filename = `Screenshot-${Date.now()}` }) => {
   verifyBin(['gnome-screenshot'])
 
   const folder = process.cwd()
-  const file = path.join(folder, `${filename || `Screenshot-${Date.now()}`}.png`)
+  const filepath = path.join(folder, filename)
 
-  shell.exec(`gnome-screenshot -a --file ${file}`)
+  shell.exec(`gnome-screenshot -a --file "${filepath}.png"`)
 }
 
 module.exports = screenshot


### PR DESCRIPTION
- Refactoring script postinstall
- 2.26.4
- npm update && npm audit fix
- Using helper getUserPassword at update command
- Printing only the error message when user password is wrong
- 2.26.5
- New package: folquire
- update folquire
- update folquire
- Refactoring src/helpers/index.js
- 2.26.6
- npm update && npm audit fix
- 2.26.7
- npm update && npm audit fix
- 2.26.8
- npm update && npm audit fix
- Update dependency folquire
- update jest
- 2.26.9
- npm update && npm audit fix
- Screenshot command saving image in the current folder; New screenshot param: --filename
- 2.27.0
- npm update && npm audit fix
- Removing node 10.x from node.js.yml workflow
- Refactoring command 'screenshot'
- 2.27.1
